### PR TITLE
Changed default port to 9000

### DIFF
--- a/drivers/squeezebox/pair/start.html
+++ b/drivers/squeezebox/pair/start.html
@@ -35,7 +35,7 @@
 	<span class="input-wrap">
 		<label for="address" data-i18n="pair.title_manual">Manual</label>
 		<input type="text" id="address" placeholder="Address (IP or hostname)" value="" />
-		<input type="text" id="port" placeholder="Server port (e.g. 9002)" value="9002" />
+		<input type="text" id="port" placeholder="Server port (e.g. 9000)" value="9000" />
 		<button class="button" id="validate" data-i18n="pair.button_get">Get players</button>
 		<i class="smile-status smile-loading fa fa-circle-o-notch fa-spin"></i>
 		<i class="smile-status smile-ok fa fa-check" style="color: #96ff00;"></i>


### PR DESCRIPTION
I think the default port for LMS is 9000.
The default was set to 9002 and therefore have to be changed by most people when adding a device in Homey.